### PR TITLE
testジョブの実行環境をmacOSに変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,5 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-      - run: bunx playwright install --with-deps --only-shell chromium
+      - run: bunx playwright install --only-shell chromium
       - run: bunx vitest --reporter=github-actions


### PR DESCRIPTION
Linux環境だとブラウザ実行に必要なシステム依存関係のインストールにやたら時間がかかることがあるため、システム依存関係のインストールの必要がないMacOS環境で`test`ジョブを実行する。